### PR TITLE
println in wrap-with-logger is cluttering stdout

### DIFF
--- a/src/ring/logger/onelog.clj
+++ b/src/ring/logger/onelog.clj
@@ -68,7 +68,6 @@
   Supported options are the same as of ring.logger/wrap-with-logger, except for
   :logger which is fixed to a OnelogLogger instance"
   ([handler options]
-   (println "onelog wrap-with-logger")
    (logger/wrap-with-logger
      handler
      (merge options {:logger (make-onelog-logger options)})))


### PR DESCRIPTION
This println isn't necessary, is it?

This is my first ever pull request, sorry if its crude.
